### PR TITLE
Mention DebOps under Roles as DebOps has roles for all listed apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collaborative curated list of awesome Ansible resources
   - Nginx : [Github](https://github.com/jdauphant/ansible-role-nginx) / [Galaxy](https://galaxy.ansible.com/list#/roles/466)
   - PostgreSQL : [Github](https://github.com/ANXS/postgresql) / [Galaxy](https://galaxy.ansible.com/list#/roles/512)
   - Redis : [Github](https://github.com/DavidWittman/ansible-redis) / [Galaxy](https://galaxy.ansible.com/detail#/role/730)
+  - [DebOps](https://debops.org/) should have roles for all applications mentioned above which can also be used individually.
 - Playbooks
   - [Ansible Examples](https://github.com/ansible/ansible-examples) - This tutorial presents ansible step-by-step
   - [Ansible Desktop](https://github.com/kalos/ansible-desktop)


### PR DESCRIPTION
That a set of playbooks also has nicely packaged roles which work individually is not the default. It is kind of unique for DebOps as far as I have seen other projects. Maybe it can be mentioned?

Related to: #9
CC: @drybjed,  @it-praktyk