### PR TITLE
Add Ansible Vagrant Examples playbooks link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A collaborative curated list of awesome Ansible resources
 - [Ansible Examples](https://github.com/ansible/ansible-examples) - This tutorial presents ansible step-by-step
 - [Ansible Desktop](https://github.com/kalos/ansible-desktop)
 - [Ansible Tutorial](https://github.com/leucos/ansible-tuto)
+- [Ansible Vagrant Examples](https://github.com/geerlingguy/ansible-vagrant-examples)
 - [DebOps](https://debops.org/) - Your Debian-based data center in a box. A collection of Ansible playbooks, scalable from one container to an entire data center.
 - [fgci-ansible](https://github.com/CSCfi/fgci-ansible) - Collection of the Finnish Grid and Cloud Infrastructure Ansible playbooks (CentOS)
 - [FreeBSD](https://github.com/jdauphant/ansible-freebsd-playbooks) - Playbook example for FreeBSD


### PR DESCRIPTION
If you'd be okay adding this link, it contains a number of example playbooks which use Vagrant and Ansible Galaxy roles to demonstrate easy setup of various apps using Ansible.